### PR TITLE
Adjust graph time scale to 1h and remove markers

### DIFF
--- a/cpu-monitoring-example/src/App.tsx
+++ b/cpu-monitoring-example/src/App.tsx
@@ -43,7 +43,7 @@ const App = ({
     return new AstarteAPIClient({ astarteUrl, realm, token });
   }, [astarteUrl, realm, token]);
 
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const since = new Date(Date.now() - 60 * 60 * 1000);
 
   useEffect(() => {
     const { polling, websocket } = interfaces(

--- a/cpu-monitoring-example/src/components/DataChart.tsx
+++ b/cpu-monitoring-example/src/components/DataChart.tsx
@@ -55,7 +55,6 @@ const DataChart = ({ data, title }: DataChartProps) => {
         curve: "straight",
         width: 1,
       },
-      markers: { size: 3 },
       grid: {
         xaxis: {
           lines: {


### PR DESCRIPTION
Shorten graph time scale from 24h to 1h and remove markers for better visualization